### PR TITLE
Fix `asMinutes` label

### DIFF
--- a/script.js
+++ b/script.js
@@ -120,7 +120,7 @@ function renderBuildTimes(container, barValue, data, baseUrl) {
 	}
 
 	function asMinutes(val) {
-		return f(val / 60) + 'h';
+		return f(val / 60) + 'm';
 	}
 
 	function asHours(val) {


### PR DESCRIPTION
This causes charts to show e.g. `5.0h` instead of `5.0m`:

<img src="https://user-images.githubusercontent.com/227022/27730955-7b84e192-5d8b-11e7-9ebc-6281c9f70128.png" width="450">