### PR TITLE
Fix a couple more bugs

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,8 +92,8 @@ function renderBuildTimes(container, barValue, data, baseUrl) {
 
 	// scales
 	var yScale = d3.scaleBand()
-		.domain(d3.range(0, data.length))
-		.range([0, data.length * (barHeight+barPaddingV)]);
+		.domain(d3.range(0, data.length + 1))
+		.range([0, (data.length + 1) * (barHeight+barPaddingV)]);
 	var y = function(d, i) { return yScale(i) + barPaddingV*i; };
 	var yText = function(d, i) { return y(d, i) + yScale.rangeBand() / 2; };
 

--- a/script.js
+++ b/script.js
@@ -291,7 +291,7 @@ function updateInputViaHash() {
 	document.getElementById('repository').value = parts[0] + '/' + parts[1]; 
 
 	if (parts[2]) {
-		document.getElementById('branch').value = parts[2];
+		document.getElementById('branch').value = parts.slice(2).join('/');
 	}
 }
 


### PR DESCRIPTION
- Support branch names containing `/` slashes
- Fix rendering the charts with only a single bar (the upper bound of `d3.range` [is exclusive; it is not included in the result. ](https://github.com/d3/d3-array/blob/master/README.md#range))

To try out both of these fixes, visit `#WordPress/gutenberg/update/travis-npm-5` (`WordPress/gutenberg` repo, `update/travis-npm-5` branch).